### PR TITLE
Fix failures when installing the plugin to es 6.4.3

### DIFF
--- a/elasticsearch/plugin-descriptor.properties
+++ b/elasticsearch/plugin-descriptor.properties
@@ -3,4 +3,4 @@ version=1.0.0
 name=VectorSearchPlugin
 classname=org.elasticsearch.VectorSearchPlugin
 java.version=1.8
-elasticsearch.version=6.2.4
+elasticsearch.version=6.4.3

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -7,7 +7,7 @@
     <fileSets>
         <fileSet>
             <directory>elasticsearch</directory>
-            <outputDirectory>elasticsearch</outputDirectory>
+            <outputDirectory></outputDirectory>
             <includes>
                 <include>plugin-descriptor.properties</include>
             </includes>
@@ -16,7 +16,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>elasticsearch</outputDirectory>
+            <outputDirectory></outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>


### PR DESCRIPTION
Hello @EikeDehling 

Thank you very much for this valuable plugin.

When I installing this plugin to ES 6.4.3, I failed to install this plugin with the following error messages.

```
➜ bin/elasticsearch-plugin install file:///Users/takahi-i/IdeaProjects/vector-search-plugin/target/releases/vector-search-plugin-0.9.9.zip
-> Downloading file:///Users/takahi-i/IdeaProjects/vector-search-plugin/target/releases/vector-search-plugin-0.9.9.zip
[=================================================] 100%
ERROR: This plugin was built with an older plugin structure. Contact the plugin author to remove the intermediate "elasticsearch" directory within the plugin zip.
```

The same problem occurs in other plugins (see https://github.com/codelibs/elasticsearch-analysis-kuromoji-neologd/issues/9).

This failure can be fixed removing `elasticsearch` directory in plugin zip file. I made this pull request to fix the failure. With this change, I succeeded to install this plugin as follows.

```
➜  elasticsearch-6.4.3 git:(master) ✗ bin/elasticsearch-plugin install file:///Users/takahi-i/IdeaProjects/vector-search-plugin/target/releases/vector-search-plugin-0.9.9.zip
-> Downloading file:///Users/takahi-i/IdeaProjects/vector-search-plugin/target/releases/vector-search-plugin-0.9.9.zip
[=================================================] 100%
-> Installed VectorSearchPlugin
```

Thanks

 